### PR TITLE
Web dip missed turn schema

### DIFF
--- a/admin/adminActions.php
+++ b/admin/adminActions.php
@@ -75,7 +75,7 @@ class adminActions extends adminActionsForms
 			),
 			'tempBan' => array(
 				'name' => 'Temporary ban a player',
-				'description' => 'Stops a player from joining or creating new games for that many days. To remove a temp ban, enter 0 days',
+				'description' => 'Stops a player from (re)joining or creating new games for that many days. To remove a temp ban, enter 0 days',
 				'params' => array('userID'=>'User ID', 'ban'=>'Days')
 			),
 			'banUser' => array(
@@ -1147,9 +1147,9 @@ class adminActions extends adminActionsForms
 		User::tempBanUser($userID, $days);
 		
  		if ($days == 0)
-			return 'This user is now unblocked and can join and create games again.';
+			return 'This user is now unblocked and can (re)join and create games again.';
 			
-		return 'This user is now blocked from joining and creating games for <b>'.$days.'</b> days.';
+		return 'This user is now blocked from (re)joining and creating games for <b>'.$days.'</b> days.';
 	}
 	public function givePoints(array $params)
 	{

--- a/admin/adminActions.php
+++ b/admin/adminActions.php
@@ -1143,7 +1143,9 @@ class adminActions extends adminActionsForms
 		
 		$userID = (int)$params['userID'];
 		$days   = (int)$params['ban'];
- 		$DB->sql_put("UPDATE wD_Users SET tempBan = ". ( time() + ($days * 86400) )." WHERE id=".$userID);
+ 		
+		User::tempBanUser($userID, $days);
+		
  		if ($days == 0)
 			return 'This user is now unblocked and can join and create games again.';
 			

--- a/board.php
+++ b/board.php
@@ -83,7 +83,7 @@ else
 		// If viewing an archive page make that the title, otherwise us the name of the game
 		libHTML::starthtml(isset($_REQUEST['viewArchive'])?$_REQUEST['viewArchive']:$Game->titleBarName());
 		
-		if ( $Game->Members->isJoined() )
+		if ( $Game->Members->isJoined() && !$Game->Members->isTempBanned() )
 		{
 			// We are a member, load the extra code that we might need
 			require_once(l_r('gamemaster/gamemaster.php'));

--- a/board/chatbox.php
+++ b/board/chatbox.php
@@ -62,7 +62,7 @@ class Chatbox
 			$msgCountryID = 0;
 
 		// Enforce Global and Notes tabs when its not Regular press game.
-		if ( ($Game->pressType != 'Regular' && $Game->pressType != 'RulebookPress') && !(isset($Member) && $Member->countryID == $msgCountryID) )
+		if ( (($Game->pressType != 'Regular' && $Game->pressType != 'RulebookPress') || (isset($Game) && $Game->Members->isTempBanned())) && !(isset($Member) && $Member->countryID == $msgCountryID) )
 			$msgCountryID = 0;
 
 		$_SESSION[$Game->id.'_msgCountryID'] = $msgCountryID;

--- a/board/member.php
+++ b/board/member.php
@@ -64,7 +64,10 @@ class userMember extends panelMember
 	 */
 	protected function setBackFromLeft()
 	{
-		global $DB,$Game;
+		global $DB,$Game,$User;
+		
+		if ( $this->Game->Members->isTempBanned() )
+			throw new Exception("You are blocked from rejoining your games.");
 
 		unset($this->Game->Members->ByStatus[$this->status][$this->id]);
 		$this->status = 'Playing';

--- a/css/desktopOnly/gamepanel.css
+++ b/css/desktopOnly/gamepanel.css
@@ -431,7 +431,7 @@ div.memberBoardHeader {
 	font-size:11px;
 }
 
-.panelAnonOnlyFlag {
+.panelAnonOnlyFlag, .panelTempBanned {
 	background-color:#f5f5f5  !important;
 	text-align: center !important;
 	}

--- a/css/gamepanel.css
+++ b/css/gamepanel.css
@@ -431,7 +431,7 @@ div.memberBoardHeader {
 	font-size:11px;
 }
 
-.panelAnonOnlyFlag {
+.panelAnonOnlyFlag, .panelTempBanned{
 	background-color:#f5f5f5  !important;
 	text-align: center !important;
 	}

--- a/gamemaster/member.php
+++ b/gamemaster/member.php
@@ -476,7 +476,7 @@ class processMember extends Member
 				SET m.excusedMissedTurns = ".$this->excusedMissedTurns."
 				WHERE m.id = ".$this->id);
 		
-		$this->send('No','No',l_t("You have missed a deadline and lost an excuse (%s left)."
+		$this->send('No','No',l_t("You have missed a deadline and lost an excuse (%s left). "
 				. "Be more reliable!",$this->excusedMissedTurns));
 	}
 }

--- a/gamemaster/members.php
+++ b/gamemaster/members.php
@@ -669,7 +669,7 @@ class processMembers extends Members
 						FROM wD_missedTurns
 						WHERE gameID = ".$this->Game->id."
 							AND userID = ".$Member->userID."
-						ORDER BY turnDateTime DESC");
+						ORDER BY turnDateTime DESC LIMIT 1");
 			
 			list( $yearlyCount ) = $DB->sql_row("SELECT COUNT(1)
 						FROM wD_MissedTurns

--- a/gamemaster/members.php
+++ b/gamemaster/members.php
@@ -596,7 +596,7 @@ class processMembers extends Members
 	function registerNMRs($nmrs) {
 		global $DB;
 	
-		foreach( $this->ByStatus['Playing'] as $Member ){
+		foreach( $this->ByID as $Member ){
 			
 			if( in_array($Member->id, $nmrs) ){
 			
@@ -614,21 +614,138 @@ class processMembers extends Members
 		}
 	}
 	
+	private $activeNMRs = false;
 	/**
-	 * Reduces the excuses of all members with NMRs and set members with no excuses
-	 * as left. 
+	 * Check if any active NMRs (i.e. NMRs by members with status 'playing') 
+	 * were detected during NMR handling.
+	 * 
+	 * @return boolean Returns true, if there is at least one NMR by an active member.
+	 */
+	function withActiveNMRs() {
+		return $this->activeNMRs;
+	}
+	
+	/**
+	 * Handle NMRs and check, if further sanctions due to unexcused NMRs have 
+	 * to be imposed.
 	 */
 	function handleNMRs() {
+		global $DB;
 		
+		/**
+		* Check if there is at least one active NMR and for that case reduce the 
+		* excuses of all active members with NMRs and set members with no excuses
+		* as left.
+		*/
+		$this->activeNMRs = false;
 		foreach( $this->ByStatus['Playing'] as $Member ){
-			
+
 			if( $Member->missedPhases == 0 ) continue; // no NMR
+
+			$this->activeNMRs = true; // there is at least one active NMR
 			
 			if( $Member->excusedMissedTurns > 0 ){
 				$Member->removeExcuse();
 			} else {
 				$Member->setLeft();
 			}
+		}
+		
+		/*
+		 * For all player with status left, that NMRed this turn, the NMR is always
+		 * counted as unexcused. An unexcused turn might impose temp bans as
+		 * further sanctions.
+		 */
+		foreach( $this->ByStatus['Left'] as $Member ) {
+			
+			if( $Member->missedPhases == 0 ) continue; // no NMR
+			
+			/*
+			 * Check if the NMR got an excuse and count the number of unexcused NMRs 
+			 * during the last year for the member to decide what to do.
+			 */
+			list( $systemExcused, $modExcused, $samePeriodExcused ) = 
+					$DB->sql_row("SELECT systemExcused, modExcused, samePeriodExcused
+						FROM wD_missedTurns
+						WHERE gameID = ".$this->Game->id."
+							AND userID = ".$Member->userID."
+						ORDER BY turnDateTime DESC");
+			
+			list( $yearlyCount ) = $DB->sql_row("SELECT COUNT(1)
+						FROM wD_MissedTurns
+						WHERE userID = ".$Member->userID."
+							AND turnDateTime > ".time()." - (3600 * 24 * 365)
+							AND systemExcused = 0 
+							AND modExcused = 0 
+							AND samePeriodExcused = 0");
+			
+			if( $systemExcused || $modExcused ) continue; // excused miss (though a left member should not be able to get an excused miss unless mod interaction)
+			
+			$memberMsg = l_t("You have missed a deadline and have no excuses left.");
+			
+			/*
+			 * Check, if there was at last one other unexcused NMR during the last 72 hours.
+			 * In this case, this NMR will not be sanctionized.
+			 */
+			if( $samePeriodExcused ){
+				
+				$Member->send('No','No',$memberMsg." ".l_t("Due to other unexcused "
+						. "missed deadlines during the past 72 hours, this "
+						. "will only affect your Reliability Rating."));
+
+			} else {
+				
+				/*
+				 * This NMR might be sanctionized according to the yearly missed
+				 * turn count and the following table:
+				 * 
+				 * misses:
+				 * 
+				 * up to 3: warning
+				 * 4: 1-day temp ban
+				 * 5: 3-day
+				 * 6: 7-day
+				 * 7: 14-day
+				 * 8: 30-days
+				 * 9 or more: infinite (100 years)
+				 */
+				$memberMsg.=" ".l_t("You missed %s ".(($yearlyCount == 1)?"deadline":"deadlines")
+						. " without an excuse during this year.",$yearlyCount);
+				
+				if( $yearlyCount <= 3 ){
+					
+					$Member->send('No','No',$memberMsg." ".l_t("%s more "
+						. ((4-$yearlyCount == 1)?"miss":"misses")
+						. " will impose a temporary ban on you.", 4-$yearlyCount));
+					
+				} elseif( $yearlyCount >= 9){
+					
+					User::tempBanUser($Member->userID, 365 * 100, FALSE);
+					$Member->send('No','No',$memberMsg." ".l_t("Due to your unreliable behaviour "
+							. "you will be infinitely prevented from joining games. "
+							. "Contact the Mods to lift the ban."));
+					
+				} else {
+					
+					$days = 0;
+					switch($yearlyCount){
+						
+						case 4: $days = 1; break;
+						case 5: $days = 3; break;
+						case 6: $days = 7; break;
+						case 7: $days = 14; break;
+						case 8: $days = 30; break;
+					}
+					
+					User::tempBanUser($Member->userID, $days, FALSE);
+					$Member->send('No','No',$memberMsg." ".l_t("You are "
+							. "temporary banned from joining games for %s "
+							. (($days==1)?"day":"days")
+							. ". Be more reliable!", $days));	
+				}
+					
+			}
+			
 		}
 	}
 	

--- a/gamepanel/member.php
+++ b/gamepanel/member.php
@@ -34,7 +34,7 @@ class panelMember extends Member
 	function memberSentMessages()
 	{
 		global $User;
-		if($this->Game->Members->isJoined())
+		if($this->Game->Members->isJoined() && !$this->Game->Members->isTempBanned())
 			if(in_array($this->countryID,$this->Game->Members->ByUserID[$User->id]->newMessagesFrom))
 				return libHTML::unreadMessages('board.php?gameID='.$this->gameID.'&msgCountryID='.$this->countryID.'#chatbox');
 	}
@@ -50,7 +50,11 @@ class panelMember extends Member
 		
 		global $checkMissingOrders;
 		
-		if ( $this->Game->phase != 'Pre-game' && $this->Game->phase != 'Finished')
+		if( $this->Game->Members->isTempBanned() )
+		{
+			$buf .= '<div class="panelTempBanned"><b>You are blocked from rejoining this game.</b></div>';
+		}
+		elseif ( $this->Game->phase != 'Pre-game' && $this->Game->phase != 'Finished')
 		{
 			global $DB;
 			
@@ -92,12 +96,13 @@ class panelMember extends Member
 			<td class="memberRightSide '.
 				($this->status=='Left'||$this->status=='Resigned'||$this->status=='Defeated'?'memberStatusFade':'').
 				'">
-				<div>
-				<div class="memberUserDetail">
+				<div>'.
+				( $this->Game->Members->isTempBanned() ? '':
+				'<div class="memberUserDetail">
 					'.$this->memberFinalizedFull().'<br />
 					'.$this->memberMessagesFull().'
-				</div>
-				<div class="memberGameDetail">
+				</div>').
+				'<div class="memberGameDetail">
 					'.$this->memberGameDetail().'
 				</div>
 				<div style="clear:both"></div>

--- a/lib/html.php
+++ b/lib/html.php
@@ -470,7 +470,7 @@ class libHTML
 		if (isset($User) && $User->tempBan > time())
 		{
 			print '<div class="content-notice">
-					<p class="notice"><br>'.l_t('You are blocked from joining or creating new games for %s.',libTime::remainingText($User->tempBan)).'<br><br><hr></p>
+					<p class="notice"><br>'.l_t('You are blocked from (re)joining or creating new games for %s.',libTime::remainingText($User->tempBan)).'<br><br><hr></p>
 				</div>';			
 		}
 
@@ -541,7 +541,9 @@ class libHTML
 			FROM wD_Members m
 			INNER JOIN wD_Games g ON ( m.gameID = g.id )
 			WHERE m.userID = ".$User->id."
-				AND ( ( NOT m.orderStatus LIKE '%Ready%' AND NOT m.orderStatus LIKE '%None%' AND g.phase != 'Finished' ) OR NOT ( (m.newMessagesFrom+0) = 0 ) ) ORDER BY  g.processStatus ASC, g.processTime ASC");
+				AND ( ( NOT m.orderStatus LIKE '%Ready%' AND NOT m.orderStatus LIKE '%None%' AND g.phase != 'Finished' ) OR NOT ( (m.newMessagesFrom+0) = 0 ) ) ".
+				( ($User->tempBan > time()) ? "AND m.status != 'Left'" : "" ) // ingore left games of temp banned user who are banned from rejoining
+				." ORDER BY  g.processStatus ASC, g.processTime ASC");
 
 		$gameIDs = array();
 		$notifyGames = array();

--- a/message.php
+++ b/message.php
@@ -20,7 +20,7 @@ try {
     libVariant::setGlobals($Variant);
     $Game = $Variant->panelGameBoard($gameID);
 
-    if ($Game->Members->isJoined()) {
+    if ($Game->Members->isJoined() && !$Game->Members->isTempBanned()) {
         // We are a member, load the extra code that we might need
         require_once(l_r('gamemaster/gamemaster.php'));
         require_once(l_r('board/member.php'));

--- a/objects/members.php
+++ b/objects/members.php
@@ -150,6 +150,19 @@ class Members
 
 		return ( isset($this->ByUserID[$User->id]) );
 	}
+	
+	/**
+	 * Checks global $User, sees if he's a member of this game but is temp banned
+	 * from rejoining.
+	 *
+	 * @return boolean
+	 */
+	function isTempBanned()
+	{
+		global $User;
+		
+		return ( $this->isJoined() && $this->ByUserID[$User->id]->status == "Left" && $User->tempBan > time() );
+	}
 
 	function makeUserMember($userID)
 	{

--- a/objects/user.php
+++ b/objects/user.php
@@ -740,6 +740,32 @@ class User {
 		if($ip)
 			self::banIP($ip, $userID);
 	}
+	
+	/**
+	 * Temporary prevent a user from joining games.
+	 * 
+	 * @param int $userID The id of the user to be temp banned.
+	 * @param int $days The time of the ban in days.
+	 * @param boolean $overwrite True, if the temp ban value should be overwritten
+	 *		in any case. If false, an existing temp ban might be only extended (for
+	 *		automated temp bans).
+	 */
+	public static function tempBanUser($userID, $days, $overwrite = true){
+		global $DB;
+		
+		/*
+		 * If the temp ban value should only be extended (no overwrite), check
+		 * if the given time span would extend the ban. If not, do nothing.
+		 */
+		if(!$overwrite){
+			
+			list($tempBan) = $DB->sql_row("SELECT tempBan FROM wD_Users WHERE id = ".$userID);
+		
+			if( $tempBan > time() + ($days * 86400) ) return;
+		}
+		
+		$DB->sql_put("UPDATE wD_Users SET tempBan = ". ( time() + ($days * 86400) )." WHERE id=".$userID);
+	}
 
 	public function rankingDetails()
 	{


### PR DESCRIPTION
Handling of left positions now works correctly. Too many missed phases cause temporary bans. Temporary bans now prevent rejoining, too.

I noticed that you added the two attributes 'yearlyMissedTurnCount' and 'shortTermMissedTurnCount' in wD_Users. I added an update of those values in gamemaster/game.php but commented it out, as I was not sure what values should go in. Especially if excused misses should be included. What is the purpose of those attributes in the database?